### PR TITLE
Setting the AsyncViewController views backgroundcolor to be white per default

### DIFF
--- a/bytes/bytes/AsyncViewController.swift
+++ b/bytes/bytes/AsyncViewController.swift
@@ -104,6 +104,7 @@ open class AsyncViewController: UIViewController {
     override open func viewDidLoad() {
         super.viewDidLoad()
         view.addSubview(loadingView)
+        view.backgroundColor = .white
         loadingView.constrainEdges(to: view)
     }
     

--- a/bytesTests/Specs/AsyncViewControllerSpec.swift
+++ b/bytesTests/Specs/AsyncViewControllerSpec.swift
@@ -49,6 +49,12 @@ class AsyncViewControllerSpec: QuickSpec {
                 expect(weakAsync).to(beNil())
             }
         }
+        describe("view") {
+            it("should have a white background color per default") {
+                let async = AsyncViewController() { _ in return nil}
+                expect(async.view.backgroundColor) == UIColor.white
+            }
+        }
         describe("viewWillAppear") {
             it("should call the load closure") {
                 var calledLoad = false


### PR DESCRIPTION
This PR sets the AsyncViewController views background color to white as proposed in #13.