### PR TITLE
Changed the imports in the specs to not @testable import but directly import bytes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,9 +9,9 @@ target 'bytes' do
 
   target 'bytesTests' do
     inherit! :search_paths
-    pod 'Quick', '~> 1.1'
-    pod 'Nimble', '~> 7.0.2'
-    pod 'Nimble-Snapshots', '~> 6.3'
+    pod 'Quick', '~> 1.3'
+    pod 'Nimble', '~> 7.1'
+    pod 'Nimble-Snapshots', '~> 6.7'
   end
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,35 +1,35 @@
 PODS:
-  - FBSnapshotTestCase (2.1.4):
-    - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
-  - FBSnapshotTestCase/Core (2.1.4)
-  - FBSnapshotTestCase/SwiftSupport (2.1.4):
-    - FBSnapshotTestCase/Core
-  - Nimble (7.0.2)
-  - Nimble-Snapshots (6.3.0):
-    - Nimble-Snapshots/Core (= 6.3.0)
-  - Nimble-Snapshots/Core (6.3.0):
-    - FBSnapshotTestCase (~> 2.0)
+  - iOSSnapshotTestCase (3.0.0):
+    - iOSSnapshotTestCase/SwiftSupport (= 3.0.0)
+  - iOSSnapshotTestCase/Core (3.0.0)
+  - iOSSnapshotTestCase/SwiftSupport (3.0.0):
+    - iOSSnapshotTestCase/Core
+  - Nimble (7.1.3)
+  - Nimble-Snapshots (6.7.1):
+    - Nimble-Snapshots/Core (= 6.7.1)
+  - Nimble-Snapshots/Core (6.7.1):
+    - iOSSnapshotTestCase (~> 3.0)
     - Nimble (~> 7.0)
-  - Quick (1.2.0)
+  - Quick (1.3.1)
 
 DEPENDENCIES:
-  - Nimble (~> 7.0.2)
-  - Nimble-Snapshots (~> 6.3)
-  - Quick (~> 1.1)
+  - Nimble (~> 7.1)
+  - Nimble-Snapshots (~> 6.7)
+  - Quick (~> 1.3)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
-    - FBSnapshotTestCase
+    - iOSSnapshotTestCase
     - Nimble
     - Nimble-Snapshots
     - Quick
 
 SPEC CHECKSUMS:
-  FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  Nimble: bfe1f814edabba69ff145cb1283e04ed636a67f2
-  Nimble-Snapshots: f5459b5b091678dc942d03ec4741cacb58ba4a52
-  Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
+  iOSSnapshotTestCase: 23984ffe05289728d646cbb6a7a10b4fb1c93440
+  Nimble: 2839b01d1b31f6a6a7777a221f0d91cf52e8e27b
+  Nimble-Snapshots: 7ab1d5fd4a794b983805c6f6b8091fb00d772754
+  Quick: d17304d58d0d169dd0bd1c6e5c28e3318de32a1a
 
-PODFILE CHECKSUM: 3460af7be72e63cd1924cfe764d39a5bdcdee0b6
+PODFILE CHECKSUM: 218b25114e88d50a903204644630adc599c7bd85
 
 COCOAPODS: 1.5.3

--- a/bytes.xcodeproj/project.pbxproj
+++ b/bytes.xcodeproj/project.pbxproj
@@ -450,17 +450,17 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-bytesTests/Pods-bytesTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/FBSnapshotTestCase/FBSnapshotTestCase.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble-Snapshots/Nimble_Snapshots.framework",
 				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
+				"${BUILT_PRODUCTS_DIR}/iOSSnapshotTestCase/FBSnapshotTestCase.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble_Snapshots.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/bytes/bytes/SemanticVersion.swift
+++ b/bytes/bytes/SemanticVersion.swift
@@ -26,7 +26,7 @@ public struct SemanticVersion {
     ///   - minor: The minor version. Default = 0
     ///   - patch: The patch version. Default = 0
     ///   - prereleaseIdentifiers: All aditional prereleaseIdentifiers. Default = none.
-    init(major: Int8, minor: Int8?, patch: Int8?, prereleaseIdentifiers: [String] = []) {
+    public init(major: Int8, minor: Int8?, patch: Int8?, prereleaseIdentifiers: [String] = []) {
         self.major = major
         self.minor = minor ?? 0
         self.patch = patch ?? 0
@@ -38,7 +38,7 @@ public struct SemanticVersion {
     ///
     /// - Parameters:
     ///   - string: The string to parse.
-    init?(_ string: String) {
+    public init?(_ string: String) {
         let basic: [String] = string.trimmingCharacters(in: .whitespaces).components(separatedBy: "-")
         let components = basic[0].components(separatedBy: ".")
         guard let major = Int8(components[0]) else { return nil }

--- a/bytesTests/Specs/ApplicationSpec.swift
+++ b/bytesTests/Specs/ApplicationSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/AsyncViewControllerSpec.swift
+++ b/bytesTests/Specs/AsyncViewControllerSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/ByteCountFormatter+PreconfiguredSpec.swift
+++ b/bytesTests/Specs/ByteCountFormatter+PreconfiguredSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/Collection+JoinNSAttributedStringsSpec.swift
+++ b/bytesTests/Specs/Collection+JoinNSAttributedStringsSpec.swift
@@ -6,9 +6,7 @@
 //  Copyright © 2017 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-import Foundation
-
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/DateComponentsFormatter+PreconfiguredSpec.swift
+++ b/bytesTests/Specs/DateComponentsFormatter+PreconfiguredSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/DateFormatter+PreconfiguredSpec.swift
+++ b/bytesTests/Specs/DateFormatter+PreconfiguredSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/DeviceSpec.swift
+++ b/bytesTests/Specs/DeviceSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/Dictionary+DiffSpec.swift
+++ b/bytesTests/Specs/Dictionary+DiffSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/Dictionary+MergeSpecs.swift
+++ b/bytesTests/Specs/Dictionary+MergeSpecs.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/DiscardTouchViewSpec.swift
+++ b/bytesTests/Specs/DiscardTouchViewSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/IconFontSpec.swift
+++ b/bytesTests/Specs/IconFontSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/Int+RandomSpec.swift
+++ b/bytesTests/Specs/Int+RandomSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/NSArray+ShuffledSpec.swift
+++ b/bytesTests/Specs/NSArray+ShuffledSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/NumberFormatter+PreconfiguredSpec.swift
+++ b/bytesTests/Specs/NumberFormatter+PreconfiguredSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/SemanticVersionSpec.swift
+++ b/bytesTests/Specs/SemanticVersionSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/String+HashesSpec.swift
+++ b/bytesTests/Specs/String+HashesSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/String+RandomSpec.swift
+++ b/bytesTests/Specs/String+RandomSpec.swift
@@ -7,7 +7,7 @@
 //
 
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/UIColor+ComponentsSpec.swift
+++ b/bytesTests/Specs/UIColor+ComponentsSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/UIColor+HexSpec.swift
+++ b/bytesTests/Specs/UIColor+HexSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/UIImage+ColorSpec.swift
+++ b/bytesTests/Specs/UIImage+ColorSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/UIImage+TransformationsSpec.swift
+++ b/bytesTests/Specs/UIImage+TransformationsSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import UIKit
 import Quick

--- a/bytesTests/Specs/UIView+ConstraintsSpec.swift
+++ b/bytesTests/Specs/UIView+ConstraintsSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/UIView+RenderingSpecs.swift
+++ b/bytesTests/Specs/UIView+RenderingSpecs.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/UIViewController+HierarchieSpec.swift
+++ b/bytesTests/Specs/UIViewController+HierarchieSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble

--- a/bytesTests/Specs/URL+QueryItemsSpec.swift
+++ b/bytesTests/Specs/URL+QueryItemsSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 TBO INTERACTIVE GmbH & Co. KG. All rights reserved.
 //
 
-@testable import bytes
+import bytes
 
 import Quick
 import Nimble


### PR DESCRIPTION
In the past there were quite some occurrences, where some feature was internal or private so it couldn't be used. In this PR I changed all specs so they `import bytes` and not `@testable import bytes`. This catches these bugs.

While doing that I found such an issue in the `SemanticVersion` and fixed it.