### PR TITLE
Deprecating and renaming the bool.random function here in bytes

### DIFF
--- a/bytes/bytes/Extensions/Bool+Random.swift
+++ b/bytes/bytes/Extensions/Bool+Random.swift
@@ -13,7 +13,8 @@ public extension Bool {
     /// Returns a random bool value
     ///
     /// - Returns: A random bool value
-    public static func random() -> Bool {
+    @available(*, deprecated, message: "Use the random() function instead")
+    public static func randomBool() -> Bool {
         return arc4random_uniform(2) == 0
     }
 }


### PR DESCRIPTION
I decided to not completely remove this function but rename and deprecate it. This way there is still a `random` function if you are not using the new Xcode.