### PR TITLE
Update for Swift 5

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '8.2'
+platform :ios, '10.0'
 
 target 'bytes' do
   # Comment this line if you're not using Swift and don't want to use dynamic frameworks
@@ -9,9 +9,9 @@ target 'bytes' do
 
   target 'bytesTests' do
     inherit! :search_paths
-    pod 'Quick', '~> 1.3'
-    pod 'Nimble', '~> 7.1'
-    pod 'Nimble-Snapshots', '~> 6.7'
+    pod 'Quick', '~> 2.1'
+    pod 'Nimble', '~> 8.0'
+    pod 'Nimble-Snapshots', '~> 7.1'
   end
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
-  - iOSSnapshotTestCase (4.0.0):
-    - iOSSnapshotTestCase/SwiftSupport (= 4.0.0)
-  - iOSSnapshotTestCase/Core (4.0.0)
-  - iOSSnapshotTestCase/SwiftSupport (4.0.0):
+  - iOSSnapshotTestCase (6.1.0):
+    - iOSSnapshotTestCase/SwiftSupport (= 6.1.0)
+  - iOSSnapshotTestCase/Core (6.1.0)
+  - iOSSnapshotTestCase/SwiftSupport (6.1.0):
     - iOSSnapshotTestCase/Core
-  - Nimble (7.3.1)
-  - Nimble-Snapshots (6.9.0):
-    - Nimble-Snapshots/Core (= 6.9.0)
-  - Nimble-Snapshots/Core (6.9.0):
-    - iOSSnapshotTestCase (~> 4.0)
-    - Nimble (~> 7.0)
-  - Quick (1.3.2)
+  - Nimble (8.0.2)
+  - Nimble-Snapshots (7.1.0):
+    - Nimble-Snapshots/Core (= 7.1.0)
+  - Nimble-Snapshots/Core (7.1.0):
+    - iOSSnapshotTestCase (~> 6.0)
+    - Nimble (~> 8.0)
+  - Quick (2.1.0)
 
 DEPENDENCIES:
-  - Nimble (~> 7.1)
-  - Nimble-Snapshots (~> 6.7)
-  - Quick (~> 1.3)
+  - Nimble (~> 8.0)
+  - Nimble-Snapshots (~> 7.1)
+  - Quick (~> 2.1)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -25,11 +25,11 @@ SPEC REPOS:
     - Quick
 
 SPEC CHECKSUMS:
-  iOSSnapshotTestCase: 711379b19f69a22c131527df862352c877c2773c
-  Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
-  Nimble-Snapshots: 79394f8d0aea3df54bd5ff78ee9dff05a523a09c
-  Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
+  iOSSnapshotTestCase: 30d540b0c8feb9d7f8ff97acc25a3804b48ee264
+  Nimble: 622629381bda1dd5678162f21f1368cec7cbba60
+  Nimble-Snapshots: 2ec985281eef0eb9fc69a469deee851363a50d0e
+  Quick: 4be43f6634acfa727dd106bdf3929ce125ffa79d
 
-PODFILE CHECKSUM: eee41a68ab7620ca035da093e4189ce56698ad49
+PODFILE CHECKSUM: 65f62f0d6f3f197088f3cc7e2148686788d9f9fa
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.1

--- a/bytes.podspec
+++ b/bytes.podspec
@@ -22,7 +22,9 @@ Pod::Spec.new do |s|
 
   s.author      = { "Cornelius Horstmann" => "horstmann@tbointeractive.com", "Thorsten Stark" => "stark@tbo.de", "Bernhard Eiling" => "eiling@tbointeractive.com", "Pascal Stüdlein" => "stuedlein@tbointeractive.com"  }
 
-  s.platform     = :ios, "8.2"
+  s.platform     = :ios, "10.0"
+  
+  s.swift_versions = ['4.2', '5.0']
 
   s.source       = { :git => "https://github.com/tbointeractive/bytes.git", :tag => 'v1.1'}
 

--- a/bytes.xcodeproj/project.pbxproj
+++ b/bytes.xcodeproj/project.pbxproj
@@ -404,12 +404,12 @@
 				TargetAttributes = {
 					1FF0F0DB1DBF4F61002BE0C9 = {
 						CreatedOnToolsVersion = 8.0;
-						LastSwiftMigration = 0940;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					1FF0F0EF1DBF4F61002BE0C9 = {
 						CreatedOnToolsVersion = 8.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 1FF0F0DB1DBF4F61002BE0C9;
 					};
@@ -420,6 +420,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -484,7 +485,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-bytesTests/Pods-bytesTests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-bytesTests/Pods-bytesTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble-Snapshots/Nimble_Snapshots.framework",
 				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
@@ -499,7 +500,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-bytesTests/Pods-bytesTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bytesTests/Pods-bytesTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		DE677C400D70891480A4E090 /* [CP] Check Pods Manifest.lock */ = {
@@ -677,7 +678,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -738,7 +739,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "${SRCROOT}/Cocoapods/appletvos";
@@ -761,13 +762,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = bytes/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tbointeractive.bytes;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -778,12 +779,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = bytes/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tbointeractive.bytes;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -799,7 +800,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.tbointeractive.bytesTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/bytes.app/bytes";
 			};
 			name = Debug;
@@ -815,7 +816,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tbointeractive.bytesTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/bytes.app/bytes";
 			};
 			name = Release;

--- a/bytes/bytes/Extensions/String+Hashes.swift
+++ b/bytes/bytes/Extensions/String+Hashes.swift
@@ -9,7 +9,7 @@
 import Foundation
 import CCommonCrypto
 
-typealias CCHashSignature = (_ data: UnsafeRawPointer, _ len: CC_LONG, _ md: UnsafeMutablePointer<UInt8>) -> UnsafeMutablePointer<UInt8>!
+typealias CCHashSignature = (_ data: UnsafeRawPointer, _ len: CC_LONG, _ md: UnsafeMutablePointer<UInt8>) -> UnsafeMutablePointer<UInt8>?
 
 public extension String {
 

--- a/bytesTests/Specs/ApplicationSpec.swift
+++ b/bytesTests/Specs/ApplicationSpec.swift
@@ -24,15 +24,15 @@ class UIApplicationExtensionsSpec: QuickSpec {
         }
         describe("semanticVersion") {
             it("should be nil if the version is nil") {
-                let application = Application(name: nil, displayName: nil, buildVersion: nil, version: nil)
+                let application = Application(name: nil, displayName: nil, buildVersion: nil, version: nil, bundleIdentifier:nil)
                 expect(application.semanticVersion).to(beNil())
             }
             it("should be nil if the version has an invalid format") {
-                let application = Application(name: nil, displayName: nil, buildVersion: nil, version: "this is not a valid version")
+                let application = Application(name: nil, displayName: nil, buildVersion: nil, version: "this is not a valid version", bundleIdentifier: nil)
                 expect(application.semanticVersion).to(beNil())
             }
             it("should be not nil if the version has a valid format") {
-                let application = Application(name: nil, displayName: nil, buildVersion: nil, version: "1.2.3")
+                let application = Application(name: nil, displayName: nil, buildVersion: nil, version: "1.2.3", bundleIdentifier: nil)
                 expect(application.semanticVersion).toNot(beNil())
                 expect(application.semanticVersion?.description) == "1.2.3"
             }

--- a/bytesTests/Specs/String+RandomSpec.swift
+++ b/bytesTests/Specs/String+RandomSpec.swift
@@ -22,7 +22,7 @@ class StringRandomSpec: QuickSpec {
             }
             it ("should return a string which contains only characters within the given array") {
                 let randomString = String.random(with: chars, length: 20)
-                for char in randomString.characters {
+                for char in randomString {
                     expect(chars.contains(char)).to(beTrue())
                 }
             }


### PR DESCRIPTION
To support newer versions of Quick/Nimble it was necessary to increase minimum iOS version to 10.0.